### PR TITLE
Validating an unsigned token with a key should be false.

### DIFF
--- a/src/clj_jwt/core.clj
+++ b/src/clj_jwt/core.clj
@@ -68,6 +68,9 @@
     ([this key]
      (let [alg (-> this :header :alg keyword)]
        (cond
+         (and (= :none alg) (not (= "" key)))
+         false
+
          (= :none alg) (= "" (:signature this))
 
          (supported-algorithm? alg)
@@ -87,4 +90,3 @@
     (->JWT (encoded-json->map header)
            (encoded-json->map claims)
            (or signature ""))))
-

--- a/test/clj_jwt/core_test.clj
+++ b/test/clj_jwt/core_test.clj
@@ -98,16 +98,19 @@
   (fact "HS256 signed JWT should be verified."
     (-> claim jwt (sign "foo") (verify "foo"))                 => true
     (-> claim jwt (sign "foo") to-str str->jwt (verify "foo")) => true
+    (-> claim jwt              to-str str->jwt (verify "foo")) => false
     (-> claim jwt (sign "foo") (verify "bar"))                 => false)
 
   (fact "HS384 signed JWT should be verified."
     (-> claim jwt (sign :HS384 "foo") (verify "foo"))                 => true
     (-> claim jwt (sign :HS384 "foo") to-str str->jwt (verify "foo")) => true
+    (-> claim jwt                     to-str str->jwt (verify "foo")) => false
     (-> claim jwt (sign :HS384 "foo") (verify "bar"))                 => false)
 
   (fact "HS512 signed JWT should be verified."
     (-> claim jwt (sign :HS512 "foo") (verify "foo"))                 => true
     (-> claim jwt (sign :HS512 "foo") to-str str->jwt (verify "foo")) => true
+    (-> claim jwt                     to-str str->jwt (verify "foo")) => false
     (-> claim jwt (sign :HS512 "foo") (verify "bar"))                 => false)
 
   (fact "RS256 signed JWT should be verified."


### PR DESCRIPTION
If the token supplied to the `verify` function is has a signature which
is an empty-string, the key is ignored, presuming that the token is
unsigned and that the calling code is not interested in ensuring the
token has been signed.

If the calling code is trying to verify that the token was signed with
their secret key, it is possible for a completely unsigned token to be
accepted as valid.

This patch adds a check to ensure that if the token is unsigned, but a
non-empty key was supplied to `validate`, then the token is considered
to not be valid.

See github issue https://github.com/liquidz/clj-jwt/issues/8
