### PR TITLE
Upgraded to Bouncy Castle 1.50 and removed direct calls to addProvider

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -6,9 +6,8 @@
   :dependencies [[org.clojure/clojure "1.6.0"]
                  [org.clojure/data.json "0.2.6"]
                  [org.clojure/data.codec "0.1.0"]
-                 [org.bouncycastle/bcprov-jdk15 "1.46"]
+                 [org.bouncycastle/bcpkix-jdk15on "1.50"]
                  [crypto-equality "1.0.0"]
                  [clj-time "0.9.0"]]
-
   :profiles {:dev {:dependencies [[midje "1.6.3"  :exclusions [org.clojure/clojure]]]}}
   :plugins  [[lein-midje "3.1.3"]])

--- a/src/clj_jwt/key.clj
+++ b/src/clj_jwt/key.clj
@@ -1,44 +1,84 @@
 (ns clj-jwt.key
   (:require [clojure.java.io :as io])
-  (:import  [org.bouncycastle.openssl PasswordFinder PEMReader]
+  (:import  [org.bouncycastle.openssl PEMParser PEMKeyPair PEMEncryptedKeyPair]
+            [org.bouncycastle.openssl.jcajce JcaPEMKeyConverter JcePEMDecryptorProviderBuilder]
+            [org.bouncycastle.asn1.pkcs PrivateKeyInfo]
+            [org.bouncycastle.asn1.x509 SubjectPublicKeyInfo]
+            [org.bouncycastle.cert X509CertificateHolder]
             [java.io StringReader]))
 
-(java.security.Security/addProvider
-(org.bouncycastle.jce.provider.BouncyCastleProvider.))
+(defprotocol GetPrivateKey
+  (-get-private-key [key-info password]))
 
-(defn- password-finder [s]
-  (reify PasswordFinder
-    (getPassword [this] (.toCharArray s))))
+(defprotocol GetPublicKey
+  (-get-public-key [key-info password]))
 
-(defn- pem->key
-  [reader pass-phrase]
-  (if pass-phrase
-    (.readObject (PEMReader. reader (password-finder pass-phrase)))
-    (.readObject (PEMReader. reader))))
+(defn ^JcaPEMKeyConverter pem-converter []
+  (JcaPEMKeyConverter.))
+
+(extend-protocol GetPrivateKey
+  PrivateKeyInfo
+  (-get-private-key [key-info _]
+    (.getPrivateKey (pem-converter) key-info)))
+
+(extend-protocol GetPublicKey
+  SubjectPublicKeyInfo
+  (-get-public-key [key-info _]
+    (.getPublicKey (pem-converter) key-info))
+  X509CertificateHolder
+  (-get-public-key [key-info password]
+    (-get-public-key (.getSubjectPublicKeyInfo key-info) password)))
+
+(extend-type PEMKeyPair
+  GetPrivateKey
+  (-get-private-key [key-info _]
+    (-> (pem-converter)
+        (.getKeyPair key-info)
+        .getPrivate))
+
+  GetPublicKey
+  (-get-public-key [key-info _]
+    (-> (pem-converter)
+        (.getKeyPair key-info)
+        .getPublic)))
+
+(extend-type PEMEncryptedKeyPair
+  GetPrivateKey
+  (-get-private-key [key-info ^String password]
+    (let [dec-prov (-> (JcePEMDecryptorProviderBuilder.)
+                       (.build (.toCharArray password)))]
+      (-get-private-key (-> key-info
+                           (.decryptKeyPair dec-prov)) nil)))
+  GetPublicKey
+  (-get-public-key [key-info ^String password]
+    (let [dec-prov (-> (JcePEMDecryptorProviderBuilder.)
+                       (.build (.toCharArray password)))]
+      (-get-public-key (-> key-info
+                           (.decryptKeyPair dec-prov)) nil))))
+
+(defn pem->public-key [reader pass-phrase]
+  (some-> reader
+          PEMParser.
+          .readObject
+          (-get-public-key pass-phrase)))
+
+(defn pem->private-key [reader pass-phrase]
+  (some-> reader
+          PEMParser.
+          .readObject
+          (-get-private-key pass-phrase)))
 
 (defn private-key
   [filename & [pass-phrase]]
   (with-open [r (io/reader filename)]
-    (.getPrivate
-      (pem->key r pass-phrase))))
-
-(defn- public-key? [k]
-  (let [typ (type k)]
-    (or (= org.bouncycastle.jce.provider.JCERSAPublicKey typ)
-        (= org.bouncycastle.jce.provider.JCEECPublicKey  typ))))
+    (pem->private-key r pass-phrase)))
 
 (defn public-key
   [filename & [pass-phrase]]
   (with-open [r (io/reader filename)]
-    (let [res (pem->key r pass-phrase)]
-      (if (public-key? res)
-        res
-        (.getPublic res)))))
+    (pem->public-key r pass-phrase)))
 
 (defn public-key-from-string
   [key-str & [pass-phrase]]
   (with-open [r (StringReader. key-str)]
-    (when-let [res (pem->key r pass-phrase)]
-      (if (public-key? res)
-        res
-        (.getPublic res)))))
+    (pem->public-key r pass-phrase)))

--- a/src/clj_jwt/sign.clj
+++ b/src/clj_jwt/sign.clj
@@ -3,9 +3,6 @@
     [clj-jwt.base64  :refer [url-safe-encode-str url-safe-decode]]
     [crypto.equality :refer [eq?]]))
 
-(java.security.Security/addProvider
- (org.bouncycastle.jce.provider.BouncyCastleProvider.))
-
 ; HMAC
 (defn- hmac-sign
   "Function to sign data with HMAC algorithm."
@@ -24,7 +21,7 @@
 (defn- rsa-sign
   "Function to sign data with RSA algorithm."
   [alg key body & {:keys [charset] :or {charset "UTF-8"}}]
-  (let [sig (doto (java.security.Signature/getInstance alg "BC")
+  (let [sig (doto (java.security.Signature/getInstance alg)
                   (.initSign key (java.security.SecureRandom.))
                   (.update (.getBytes body charset)))]
     (url-safe-encode-str (.sign sig))))
@@ -32,7 +29,7 @@
 (defn- rsa-verify
   "Function to verify data and signature with RSA algorithm."
   [alg key body signature & {:keys [charset] :or {charset "UTF-8"}}]
-  (let [sig (doto (java.security.Signature/getInstance alg "BC")
+  (let [sig (doto (java.security.Signature/getInstance alg)
                   (.initVerify key)
                   (.update (.getBytes body charset)))]
     (.verify sig (url-safe-decode signature))))

--- a/test/clj_jwt/key_test.clj
+++ b/test/clj_jwt/key_test.clj
@@ -1,61 +1,61 @@
 (ns clj-jwt.key-test
   (:require
     [clj-jwt.key :refer :all]
-    [midje.sweet :refer :all]))
+    [midje.sweet :refer :all]
+    [clj-jwt.core-test :refer [with-bc-provider-fn]]))
 
-(facts "rsa private key"
-  (fact "non encrypt key"
-    (type (private-key "test/files/rsa/no_pass.key"))
-    => org.bouncycastle.jce.provider.JCERSAPrivateCrtKey)
+(with-state-changes [(around :facts (with-bc-provider-fn (fn [] ?form)))]
+  (facts "rsa private key"
+    (fact "non encrypt key"
+      (type (private-key "test/files/rsa/no_pass.key"))
+      => org.bouncycastle.jcajce.provider.asymmetric.rsa.BCRSAPrivateCrtKey)
 
-  (fact "crypted key"
-    (type (private-key "test/files/rsa/3des.key" "pass phrase"))
-    => org.bouncycastle.jce.provider.JCERSAPrivateCrtKey)
+    (fact "crypted key"
+      (type (private-key "test/files/rsa/3des.key" "pass phrase"))
+      => org.bouncycastle.jcajce.provider.asymmetric.rsa.BCRSAPrivateCrtKey)
 
-  (fact "crypted key wrong pass-phrase"
-    (private-key "test/files/rsa/3des.key" "wrong pass phrase")
-    => (throws org.bouncycastle.openssl.EncryptionException)))
+    (fact "crypted key wrong pass-phrase"
+      (private-key "test/files/rsa/3des.key" "wrong pass phrase")
+      => (throws org.bouncycastle.openssl.EncryptionException)))
 
-(facts "ecdsa private key"
-  (fact "ecdsa key"
-    (type (private-key "test/files/ec/private.key"))
-    => org.bouncycastle.jce.provider.JCEECPrivateKey))
+  (facts "ecdsa private key"
+    (fact "ecdsa key"
+      (type (private-key "test/files/ec/private.key"))
+      => org.bouncycastle.jcajce.provider.asymmetric.ec.BCECPrivateKey))
 
-(facts "rsa public key"
-  (fact "rsa non encrypted key"
-    (type (public-key "test/files/rsa/no_pass.key"))
-    => org.bouncycastle.jce.provider.JCERSAPublicKey)
+  (facts "rsa public key"
+    (fact "rsa non encrypted key"
+      (type (public-key "test/files/rsa/no_pass.key"))
+      => org.bouncycastle.jcajce.provider.asymmetric.rsa.BCRSAPublicKey)
 
-  (fact "rsa encrypted key"
-    (type (public-key "test/files/rsa/3des.key" "pass phrase"))
-    => org.bouncycastle.jce.provider.JCERSAPublicKey)
+    (fact "rsa encrypted key"
+      (type (public-key "test/files/rsa/3des.key" "pass phrase"))
+      => org.bouncycastle.jcajce.provider.asymmetric.rsa.BCRSAPublicKey)
 
-  (fact "rsa encrypted key with wrong pass phrase"
-    (type (public-key "test/files/rsa/3des.key" "wrong pass phrase"))
-    => (throws org.bouncycastle.openssl.EncryptionException))
+    (fact "rsa encrypted key with wrong pass phrase"
+      (type (public-key "test/files/rsa/3des.key" "wrong pass phrase"))
+      => (throws org.bouncycastle.openssl.EncryptionException))
 
-  (fact "rsa non encrypted key from string"
-    (-> "test/files/rsa/no_pass.key" slurp public-key-from-string type)
-    => org.bouncycastle.jce.provider.JCERSAPublicKey)
+    (fact "rsa non encrypted key from string"
+      (-> "test/files/rsa/no_pass.key" slurp public-key-from-string type)
+      => org.bouncycastle.jcajce.provider.asymmetric.rsa.BCRSAPublicKey)
 
-  (fact "rsa encrypted key from string"
-    (-> "test/files/rsa/3des.key" slurp (public-key-from-string "pass phrase") type)
-    => org.bouncycastle.jce.provider.JCERSAPublicKey)
+    (fact "rsa encrypted key from string"
+      (-> "test/files/rsa/3des.key" slurp (public-key-from-string "pass phrase") type)
+      => org.bouncycastle.jcajce.provider.asymmetric.rsa.BCRSAPublicKey)
 
-  (fact "rsa encrypted key with wrong pass phrase from string"
-    (-> "test/files/rsa/3des.key" slurp (public-key-from-string "wrong pass phrase") type)
-    => (throws org.bouncycastle.openssl.EncryptionException))
+    (fact "rsa encrypted key with wrong pass phrase from string"
+      (-> "test/files/rsa/3des.key" slurp (public-key-from-string "wrong pass phrase") type)
+      => (throws org.bouncycastle.openssl.EncryptionException))
 
-  (fact "invalid key string"
-    (public-key-from-string "foobar") => nil))
+    (fact "invalid key string"
+      (public-key-from-string "foobar") => nil))
 
-(facts "ecdsa public key"
-  (fact "ecdsa public key"
-    (type (public-key "test/files/ec/public.key"))
-    => org.bouncycastle.jce.provider.JCEECPublicKey)
+  (facts "ecdsa public key"
+    (fact "ecdsa public key"
+      (type (public-key "test/files/ec/public.key"))
+      => org.bouncycastle.jcajce.provider.asymmetric.ec.BCECPublicKey)
 
-  (fact "ecdsa public key from string"
-    (-> "test/files/ec/public.key" slurp public-key-from-string type)
-    => org.bouncycastle.jce.provider.JCEECPublicKey)
-  )
-
+    (fact "ecdsa public key from string"
+      (-> "test/files/ec/public.key" slurp public-key-from-string type)
+      => org.bouncycastle.jcajce.provider.asymmetric.ec.BCECPublicKey)))

--- a/test/clj_jwt/sign_test.clj
+++ b/test/clj_jwt/sign_test.clj
@@ -3,7 +3,8 @@
     [clj-jwt.sign   :refer :all]
     [clj-jwt.base64 :refer [url-safe-encode-str]]
     [clj-jwt.key    :refer [private-key]]
-    [midje.sweet    :refer :all]))
+    [midje.sweet    :refer :all]
+    [clj-jwt.core-test :refer [with-bc-provider-fn]]))
 
 (facts "HMAC"
   (let [[hs256 hs384 hs512] (map get-signature-fn [:HS256 :HS384 :HS512])
@@ -37,16 +38,14 @@
                                "A-Z1j3LeLKFWhryRRAjzW--Ut5rs5t0MjJ4OgUUhXAEXXAeJfbeEVxzBv4C-F"
                                "e9avjnNjUgcPlJgQAMQbrLirSo8Z8hb1Iqz9f7pUuNLTkAQJA"))))
 
-(facts "EC"
-  (let [[es256 es384 es512] (map get-signature-fn [:ES256 :ES384 :ES512])
-        key  (private-key "test/files/ec/private.key")
-        body "foo"]
-    (fact "ES256"
-      (es256 key body) => string?)
-    (fact "ES384"
-      (es384 key body) => string?)
-    (fact "ES512"
-      (es512 key body) => string?)))
-
-
-
+(with-state-changes [(around :facts (with-bc-provider-fn (fn [] ?form)))]
+  (facts "EC"
+    (let [[es256 es384 es512] (map get-signature-fn [:ES256 :ES384 :ES512])
+          key  (private-key "test/files/ec/private.key")
+          body "foo"]
+      (fact "ES256"
+        (es256 key body) => string?)
+      (fact "ES384"
+        (es384 key body) => string?)
+      (fact "ES512"
+        (es512 key body) => string?))))


### PR DESCRIPTION
There's 2 main changes in this PR, an upgrade to Bouncy Castle 1.50 and removal of direct calls to add provider.

### Upgrade to bouncy castle 1.50
----
Many of the packages and class names of keys changed. It also seems like they change provider order or something similar as Sun implementations (rather than BC implementation) of some of the key classes would return in the tests.

### Remove direct calls to addProvider
----
Calling addProvider in a library makes global state changes to the JVM and can override the users desired provider order. I removed those calls and added the ability to change providers in the test suite. This will allow users of the library to define their own providers and the priority of those providers.