### PR TITLE
Use the same data to sign and verify signature

### DIFF
--- a/test/clj_jwt/core_test.clj
+++ b/test/clj_jwt/core_test.clj
@@ -98,8 +98,8 @@
 
 (facts "JWT verify"
   (fact "Unknown signature algorithm should be thrown exception."
-    (verify (->JWT {:typ "JWT" :alg "DUMMY"} claim ""))    => (throws Exception)
-    (verify (->JWT {:typ "JWT" :alg "DUMMY"} claim "") "") => (throws Exception))
+    (verify (->JWT {:typ "JWT" :alg "DUMMY"} claim "" ""))    => (throws Exception)
+    (verify (->JWT {:typ "JWT" :alg "DUMMY"} claim "" "") "") => (throws Exception))
 
   (fact "Plain JWT should be verified."
     (-> claim jwt verify)                             => true


### PR DESCRIPTION
This allow the generated JWT to be used across different versions of clojure and map implementations. I believe this can also fix https://github.com/liquidz/clj-jwt/issues/19 .
