### PR TITLE
Support for binary JWT keys in HMAC algorithms.

### DIFF
--- a/src/clj_jwt/sign.clj
+++ b/src/clj_jwt/sign.clj
@@ -7,7 +7,9 @@
 (defn- hmac-sign
   "Function to sign data with HMAC algorithm."
   [alg key body & {:keys [charset] :or {charset "UTF-8"}}]
-  (let [hmac-key (javax.crypto.spec.SecretKeySpec. (.getBytes key charset) alg)
+  (let [bin-key  (if (= (Class/forName "[B") (.getClass key)) key
+                     (.getBytes key charset))
+        hmac-key (javax.crypto.spec.SecretKeySpec. bin-key alg)
         hmac     (doto (javax.crypto.Mac/getInstance alg)
                        (.init hmac-key))]
     (url-safe-encode-str (.doFinal hmac (.getBytes body charset)))))


### PR DESCRIPTION
The existing code in clj_jwt expects the JWT key for HMAC signing to be
provided as String. This only works when the key can be represented as a
string. The keys I am using cannot be represented as String as they are
fully binary.

With this patch the key can be provided as a byte array as well.