### PR TITLE
use intended ec-verify algorithm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ pom.xml.asc
 .lein-plugins
 .lein-repl-history
 .nrepl-port
+.idea/
+*.iml

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,2 @@
 language: clojure
-lein: lein2
-script: lein2 midje
+script: lein midje

--- a/src/clj_jwt/sign.clj
+++ b/src/clj_jwt/sign.clj
@@ -46,7 +46,7 @@
 (defn ec-verify
   [alg key body signature & {:keys [charset] :or {charset "UTF-8"}}]
   (let [sig (doto (java.security.Signature/getInstance alg)
-                  (.initSign key)
+                  (.initVerify key)
                   (.update (.getBytes body charset)))]
     (.verify sig (url-safe-decode signature))))
 

--- a/src/clj_jwt/sign.clj
+++ b/src/clj_jwt/sign.clj
@@ -68,9 +68,9 @@
    :RS256 (partial rsa-verify  "SHA256withRSA")
    :RS384 (partial rsa-verify  "SHA384withRSA")
    :RS512 (partial rsa-verify  "SHA512withRSA")
-   :ES256 (partial rsa-verify  "SHA256withECDSA")
-   :ES384 (partial rsa-verify  "SHA384withECDSA")
-   :ES512 (partial rsa-verify  "SHA512withECDSA")})
+   :ES256 (partial ec-verify  "SHA256withECDSA")
+   :ES384 (partial ec-verify  "SHA384withECDSA")
+   :ES512 (partial ec-verify  "SHA512withECDSA")})
 
 (defn- get-fns [m alg]
   (if-let [f (get m alg)]


### PR DESCRIPTION
use intended ec-verify algorithm for elliptic curve signatures so as not to be misleading despite the implementation being the same as rsa-verify