### PR TITLE
fix strings in key map portability

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,3 @@
 language: clojure
-lein: lein2
-script: lein2 midje
+lein: lein
+script: lein midje

--- a/src/clj_jwt/json_key_fn.clj
+++ b/src/clj_jwt/json_key_fn.clj
@@ -2,16 +2,13 @@
   (:require
     [clojure.string :as str]))
 
-(defn write-key
-  [x]
-  (cond
-    (string? x) (str "\"" x "\"")
-    :else (name x)))
+(def write-key name)
 
 (defn read-key
+  "don't keywordize keys with / or ."
   [x]
-  (if-let [y (re-seq #"^\"(.*)\"$" x)]
-    (-> y first second)
+  (if (re-matches #".*[/.].*" x)
+    x
     (keyword x)))
 
 

--- a/test/clj_jwt/json_key_fn_test.clj
+++ b/test/clj_jwt/json_key_fn_test.clj
@@ -5,8 +5,8 @@
 
 (fact "write-key should work fine."
   (write-key :foo)  => "foo"
-  (write-key "foo") => "\"foo\"")
+  (write-key "foo") => "foo")
 
 (fact "read-key should work fine."
   (read-key "foo")     => :foo
-  (read-key "\"foo\"") => "foo")
+  (read-key "foo/bar") => "foo/bar")


### PR DESCRIPTION
Before this PR we can't provide claims like `"foo/bar"` because they will be replaced as `"\"foo/bar\""` in JSON. And using a `/` will generate the `:foo/bar` keyword causing troubles if `foo` isn't a namespace.

I think it is safe to use the rule that if a key contains a `/` or a `.`  it should be considered as string.
Otherwise we should consider it is a keyword.

I also think that this is a breaking change. So perhaps, we might prefer to provide a way to make `read-key` and `write-key` configurable.